### PR TITLE
v21 branch strategy implementation

### DIFF
--- a/tools/jenkins/Jenkinsfile
+++ b/tools/jenkins/Jenkinsfile
@@ -156,7 +156,16 @@ pipeline {
                             usernameVariable: 'SVN_USER')
                         ])
                         {
-                            sh "./Jenkins/gitdocs2svn"
+                            script {
+                                def versions = env.PRODUCTION_VERSIONS.split(' ')
+                                versions.each { version ->
+                                    sh """
+                                        SVNDOCDIR="${SVNDOCDIR}/${version}" \
+                                        GITDOCDIR="${GITDOCDIR}/${version}" \
+                                        ./Jenkins/gitdocs2svn
+                                    """
+                                }
+                            }
                         }
                     }
                 }

--- a/tools/jenkins/email.md
+++ b/tools/jenkins/email.md
@@ -1,0 +1,37 @@
+## v21 Documentation: Branch Strategy
+
+We need to start v21 documentation work while continuing to maintain the v20 docs. The goal is to let both versions coexist: v20 updates continue to flow to docs.dyalog.com as before, while v21 content is visible on GitHub Pages for internal review but does not appear on the production site until we're ready.
+
+### What changes for authors
+
+The documentation repo gets a new `v20.0` branch. Going forward:
+
+- **v20 maintenance** (bug fixes, clarifications) → PR against `v20.0`
+- **v21 new content** → PR against `main`
+
+Publishing works the same way (manual dispatch in GitHub Actions), but the version is now auto-detected from `mkdocs.yml` — no need to type it in, no risk of publishing the wrong version from the wrong branch.
+
+### What changes on the infrastructure side
+
+The Jenkinsfile gains a `PRODUCTION_VERSIONS` variable (initially set to `'20.0'`). Jenkins only deploys the versions in that list. When v21 is ready for production, we add `'21.0'` to the list — that's the only change needed.
+
+SVN paths are now computed per-version following the existing trunk/branches convention. v21 reads from trunk (same as today); v20 reads from its branches. No new SVN branches are needed right now.
+
+The `gitdocs2svn` script is unchanged — the Jenkinsfile calls it once per version with the right environment variables.
+
+Details of what's changing in the Jenkinsfile and what (little) we need from IT are in the attached `it.md`.
+
+### What changes for offline documentation
+
+Starting with v21, we're replacing CHM and PDF generation with a single offline zip built using MkDocs' offline plugin. The v20.0 branch retains the existing CHM/PDF workflow.
+
+### What's been tested
+
+All workflows have been tested end-to-end on a fork (see `steps21.md`). Version auto-detection, multi-version publishing, selective deployment, and the offline build all passed. The only thing not tested is the actual Jenkins pipeline against live infrastructure — the changes are designed to be safe (source verification before deployment, defence-in-depth exclusions) and trivially reversible.
+
+### Next steps
+
+1. Review the attached documents
+2. Coordinate with IT (the `it.md` attachment covers this — it's minimal)
+3. Merge and set up branches on the real repo
+4. First publish from both branches to verify

--- a/tools/jenkins/it.md
+++ b/tools/jenkins/it.md
@@ -1,19 +1,19 @@
-# v21 Docs: What We Need From IT
+# v21 docs repo branching implications
 
-We're splitting the documentation repo into two branches: `v20.0` (maintenance) and `main` (v21 development). The Jenkinsfile and GitHub Actions workflows have been updated and tested on a fork. See `plan21.md` for full details, `steps21.md` for test results.
+We're splitting the documentation repo into two branches: `v20.0` (maintenance) and `main` (v21 development). The Jenkinsfile and GitHub Actions workflows have been updated and tested on a fork up to but not including the Jenkins side itself. See `plan21.md` for full details, `steps21.md` for test results.
 
-## What changes in the Jenkinsfile
+## Jenkinsfile changes
 
 The Jenkinsfile on `gh-pages` (which Jenkins monitors) will be updated automatically by the publish workflow. Key differences:
 
-- **`PRODUCTION_VERSIONS = '20.0'`** replaces `DOCSVERSION = '20.0'`. Deploy/backup/verify stages now loop over this space-separated list instead of hardcoding `20.0`.
-- **`TRUNK_VERSION = '21.0'`** — controls SVN path routing (see below).
-- **`getVersionedReleaseAssets()`** — new local function replacing `ghGetReleaseAssets()` from the shared library. Filters GitHub releases by version tag prefix (`v20.0.*`, `v21.0.*`) so each version gets its own assets. Same auth pattern (`getCredentialsId('github')`), same `buildinfo.json` output.
+- `PRODUCTION_VERSIONS = '20.0'` replaces `DOCSVERSION = '20.0'`. Deploy/backup/verify stages now loop over this space-separated list instead of hardcoding `20.0`.
+- `TRUNK_VERSION = '21.0'` -- controls SVN path routing (see below).
+- `getVersionedReleaseAssets()` -- new local function replacing the use of `ghGetReleaseAssets()` from the shared library. Filters GitHub releases by version tag prefix (`v20.0.*`, `v21.0.*`) so each version gets its own assets. Same auth pattern (`getCredentialsId('github')`), same `buildinfo.json` output.
 - SVN paths are now computed per-version via helper functions instead of hardcoded env vars.
 
 ## SVN: nothing to do right now
 
-v21 is the current development version, so it reads from trunk — same paths Jenkins already uses:
+v21 is the current development version, so it reads from trunk -- same paths Jenkins already uses:
 - `docbin/trunk/documentation`
 - `dyalog/trunk/svn/docs/readmes`
 
@@ -21,24 +21,21 @@ v20.0 reads from branches (already exist):
 - `docbin/branches/20.0/documentation`
 - `dyalog/branches/20.0/svn/docs/readmes`
 
-**Future action (when v21 releases and v22 development starts):**
+Future action (when v21 releases and v22 development starts):
+
 Create these SVN branches before updating `TRUNK_VERSION` to `22.0`:
 - `docbin/branches/21.0/documentation`
 - `dyalog/branches/21.0/svn/docs/readmes`
 
-## gitdocs2svn
+## gitdocs2svn -- no changes needed
 
-The `gitdocs2svn` script in `Dyalog/JenkinsBuild` currently handles a single version. With multi-version support, release assets are now downloaded per-version into `git_docs/{version}/` and SVN checkouts go into `svn_docs/{version}/`.
+The `gitdocs2svn` script reads `$SVNDOCDIR` and `$GITDOCDIR` from the environment. The new Jenkinsfile now calls it once per version, overriding those vars to point at the per-version subdirectories (`svn_docs/20.0/`, `git_docs/20.0/`, etc.). The script itself is unchanged.
 
-Options:
-1. **Simplest**: leave `gitdocs2svn` as-is, limit `PRODUCTION_VERSIONS` to `'20.0'` until the script is updated. v21 still publishes to GitHub Pages staging; it just won't go through the SVN update path.
-2. **When ready**: update `gitdocs2svn` to accept a version parameter or loop over versions. The directory structure is already set up.
+## Unchanged
 
-## What we don't need from IT
-
-- No Jenkins job configuration changes — the Jenkinsfile is self-contained on `gh-pages`
-- No new credentials — uses existing `github` and `svn` credential IDs
-- No infrastructure changes — same agents, same Docker image, same swarm
+- No Jenkins job configuration changes -- the Jenkinsfile is self-contained on `gh-pages`
+- No new credentials -- uses existing `github` and `svn` credential IDs
+- No infrastructure changes -- same agents, same Docker image, same swarm
 
 ## Risk
 
@@ -46,8 +43,6 @@ The deploy stage now verifies source directories exist before touching productio
 
 Rollback: revert `gh-pages` Jenkinsfile to previous commit. The old single-version logic is one `git revert` away.
 
-## Questions for IT
+## Open questions
 
-1. Can you confirm `docbin/branches/20.0/documentation` and `dyalog/branches/20.0/svn/docs/readmes` exist in SVN? (They should — v20 is the current release.)
-2. Any concerns with the `getVersionedReleaseAssets` function replacing `ghGetReleaseAssets` for this pipeline? It uses the same credential ID and auth flow.
-3. Timeline for `gitdocs2svn` multi-version support — or are you happy to defer?
+1. Any concerns with the `getVersionedReleaseAssets` function replacing `ghGetReleaseAssets` for this pipeline? It uses the same credential ID and auth flow. It's fairly trivial, so local made sense, but happy to suggest a PR if we want it centrally.

--- a/tools/jenkins/it.md
+++ b/tools/jenkins/it.md
@@ -1,0 +1,53 @@
+# v21 Docs: What We Need From IT
+
+We're splitting the documentation repo into two branches: `v20.0` (maintenance) and `main` (v21 development). The Jenkinsfile and GitHub Actions workflows have been updated and tested on a fork. See `plan21.md` for full details, `steps21.md` for test results.
+
+## What changes in the Jenkinsfile
+
+The Jenkinsfile on `gh-pages` (which Jenkins monitors) will be updated automatically by the publish workflow. Key differences:
+
+- **`PRODUCTION_VERSIONS = '20.0'`** replaces `DOCSVERSION = '20.0'`. Deploy/backup/verify stages now loop over this space-separated list instead of hardcoding `20.0`.
+- **`TRUNK_VERSION = '21.0'`** — controls SVN path routing (see below).
+- **`getVersionedReleaseAssets()`** — new local function replacing `ghGetReleaseAssets()` from the shared library. Filters GitHub releases by version tag prefix (`v20.0.*`, `v21.0.*`) so each version gets its own assets. Same auth pattern (`getCredentialsId('github')`), same `buildinfo.json` output.
+- SVN paths are now computed per-version via helper functions instead of hardcoded env vars.
+
+## SVN: nothing to do right now
+
+v21 is the current development version, so it reads from trunk — same paths Jenkins already uses:
+- `docbin/trunk/documentation`
+- `dyalog/trunk/svn/docs/readmes`
+
+v20.0 reads from branches (already exist):
+- `docbin/branches/20.0/documentation`
+- `dyalog/branches/20.0/svn/docs/readmes`
+
+**Future action (when v21 releases and v22 development starts):**
+Create these SVN branches before updating `TRUNK_VERSION` to `22.0`:
+- `docbin/branches/21.0/documentation`
+- `dyalog/branches/21.0/svn/docs/readmes`
+
+## gitdocs2svn
+
+The `gitdocs2svn` script in `Dyalog/JenkinsBuild` currently handles a single version. With multi-version support, release assets are now downloaded per-version into `git_docs/{version}/` and SVN checkouts go into `svn_docs/{version}/`.
+
+Options:
+1. **Simplest**: leave `gitdocs2svn` as-is, limit `PRODUCTION_VERSIONS` to `'20.0'` until the script is updated. v21 still publishes to GitHub Pages staging; it just won't go through the SVN update path.
+2. **When ready**: update `gitdocs2svn` to accept a version parameter or loop over versions. The directory structure is already set up.
+
+## What we don't need from IT
+
+- No Jenkins job configuration changes — the Jenkinsfile is self-contained on `gh-pages`
+- No new credentials — uses existing `github` and `svn` credential IDs
+- No infrastructure changes — same agents, same Docker image, same swarm
+
+## Risk
+
+The deploy stage now verifies source directories exist before touching production. If a version directory is missing from `gh-pages`, it skips rather than wipes. The `.rsync-exclude` also blocks `21.0` as a backstop.
+
+Rollback: revert `gh-pages` Jenkinsfile to previous commit. The old single-version logic is one `git revert` away.
+
+## Questions for IT
+
+1. Can you confirm `docbin/branches/20.0/documentation` and `dyalog/branches/20.0/svn/docs/readmes` exist in SVN? (They should — v20 is the current release.)
+2. Any concerns with the `getVersionedReleaseAssets` function replacing `ghGetReleaseAssets` for this pipeline? It uses the same credential ID and auth flow.
+3. Timeline for `gitdocs2svn` multi-version support — or are you happy to defer?

--- a/tools/jenkins/plan21.md
+++ b/tools/jenkins/plan21.md
@@ -817,7 +817,7 @@ def call(String repository, directory="github_assets") {
 
 Current releases are all tagged `v20.0.*`:
 ```
-v20.0.1175  (latest — assets: dyalog.chm + 8 PDFs)
+v20.0.1175  (latest -- assets: dyalog.chm + 8 PDFs)
 v20.0.1092
 v20.0.1078
 ...
@@ -895,7 +895,26 @@ stage('Checkout from svndocs') {
 }
 ```
 
-Note: the `Update and Commit svndocs` stage runs `./Jenkins/gitdocs2svn` (from the private `Dyalog/JenkinsBuild` repo). This script likely needs a version parameter or loop to handle per-version SVN paths. Since it's in a separate repo, this change is out of scope for this plan but must be coordinated. Until `gitdocs2svn` is updated, the `Update svndocs` stage can be limited to `PRODUCTION_VERSIONS` that the script already handles (i.e., 20.0 only initially).
+The `Update and Commit svndocs` stage calls `./Jenkins/gitdocs2svn` (from `Dyalog/JenkinsBuild`) once per version, overriding `$SVNDOCDIR` and `$GITDOCDIR` to point at the per-version subdirectories. The script itself is unchanged — it already reads those vars from the environment:
+
+```groovy
+stage('Update and Commit svndocs') {
+    steps {
+        withCredentials([...]) {
+            script {
+                def versions = env.PRODUCTION_VERSIONS.split(' ')
+                versions.each { version ->
+                    sh """
+                        SVNDOCDIR="${SVNDOCDIR}/${version}" \
+                        GITDOCDIR="${GITDOCDIR}/${version}" \
+                        ./Jenkins/gitdocs2svn
+                    """
+                }
+            }
+        }
+    }
+}
+```
 
 ### Version-Specific Assets
 
@@ -904,7 +923,7 @@ Note: the `Update and Commit svndocs` stage runs `./Jenkins/gitdocs2svn` (from t
 | 20.0 | `v20.0.*` | `dyalog.chm`, `*.pdf` |
 | 21.0 | `v21.0.*` | `documentation-21.0-offline.zip` |
 
-The `get_svn_docbin` script validates against `filelist.txt` from SVN, so the different asset types don't conflict — each version's assets are in their own directory (`git_docs/20.0/`, `git_docs/21.0/`).
+The `get_svn_docbin` script validates against `filelist.txt` from SVN, so the different asset types don't conflict -- each version's assets are in their own directory (`git_docs/20.0/`, `git_docs/21.0/`).
 
 ### Future: Shared Library Update
 
@@ -928,7 +947,7 @@ If v20 and v21 need different styles (e.g., v21 has new CSS for new features), p
 
 ### Solution: Pin the v20.0 branch to a specific commit
 
-No version branches needed in `documentation-assets`. The submodule pointer on the `v20.0` documentation branch is simply frozen at the commit that was current when the branch was created. This is the default git submodule behaviour — the recorded commit doesn't change unless someone explicitly updates it.
+No version branches needed in `documentation-assets`. The submodule pointer on the `v20.0` documentation branch is simply frozen at the commit that was current when the branch was created. This is the default git submodule behaviour -- the recorded commit doesn't change unless someone explicitly updates it.
 
 The key is to **remove `--remote`** from the workflow on the `v20.0` branch. The `--remote` flag overrides the recorded commit and fetches latest from the remote branch, which is exactly what we want to avoid.
 
@@ -991,7 +1010,7 @@ The `privacy` plugin automatically downloads external assets (fonts, scripts) so
 
 `navigation.instant` (currently enabled in `mkdocs.yml` line 10) uses fetch API calls that browsers block from `file://` URLs. This must be conditionally disabled when building offline. Options:
 
-1. **Recommended: environment override in mkdocs.yml** — Material for MkDocs does not support `!ENV` toggles on individual theme features. Instead, use a `mkdocs-offline.yml` overlay or a build script that patches the config:
+1. **Recommended: environment override in mkdocs.yml** -- Material for MkDocs does not support `!ENV` toggles on individual theme features. Instead, use a `mkdocs-offline.yml` overlay or a build script that patches the config:
    ```bash
    # In the offline build step, remove navigation.instant before building
    yq -i 'del(.theme.features[] | select(. == "navigation.instant"))' mkdocs.yml
@@ -1132,7 +1151,7 @@ Key differences from the `chm-replacement` branch:
 
 The `ghGetReleaseAssets` modification described earlier still applies. For v21, the release asset is `documentation-{version}-offline.zip` instead of CHM/PDF files. The Jenkins pipeline downloads and deploys this to the `/files` directory just as it does for v20 CHM/PDF files.
 
-The `get_svn_docbin` script may need minor adjustments to handle a single zip file instead of multiple CHM/PDF files.
+The `get_svn_docbin` script (in this repo at `tools/jenkins/get_svn_docbin`) runs per-version in the `Get files from svn/docbin etc` stage. It currently expects v20-specific files from SVN docbin (`sharpplot.chm`, `setup_readme.htm`, `dyalog_readme.htm`, `filelist.txt`, `theme/header.html`). For v21, the script will need updating if the docbin/trunk layout differs — but this only matters once v21 is added to `PRODUCTION_VERSIONS`. While `PRODUCTION_VERSIONS = '20.0'`, the script only runs for v20 and works as-is.
 
 ### Version-Specific Behaviour
 
@@ -1161,4 +1180,4 @@ Starting with v21, CHM and PDF generation is replaced by a single offline zip bu
 
 Safety: the deploy stage verifies source directories exist before deleting production content, the backup stage handles missing directories gracefully, and the rsync exclude file provides defence against accidental v21 deployment.
 
-On staging (GitHub Pages), mike manages the root redirect via `index.html` and `versions.json` on `gh-pages`. Running `mike set-default latest` updates these to point to the aliased version. On production, the deploy stage currently only syncs version directories — the root-level redirect files are not deployed. This must be addressed (either by extending the deploy stage or a manual step) when v21 goes live.
+On staging (GitHub Pages), mike manages the root redirect via `index.html` and `versions.json` on `gh-pages`. Running `mike set-default latest` updates these to point to the aliased version. On production, the deploy stage currently only syncs version directories -- the root-level redirect files are not deployed. This must be addressed (either by extending the deploy stage or a manual step) when v21 goes live.

--- a/tools/jenkins/steps21.md
+++ b/tools/jenkins/steps21.md
@@ -1,4 +1,4 @@
-# v21 Branch Strategy — Steps Performed
+# v21 Branch Strategy -- Steps Performed
 
 Tracking document for all tasks performed as part of the v21 branch strategy implementation. See `plan21.md` for the full plan.
 
@@ -17,9 +17,9 @@ Tracking document for all tasks performed as part of the v21 branch strategy imp
 ### 1.2 Update `Jenkinsfile` (Plan Step 4)
 - Replaced `DOCSVERSION = '20.0'` with `PRODUCTION_VERSIONS = '20.0'` and `TRUNK_VERSION = '21.0'`
 - Removed hardcoded `SVNDOCURL` and `SVNREADMEURL` env vars
-- Added `getSvnDocbinUrl(version)` helper — trunk for TRUNK_VERSION, branches/{version} otherwise
-- Added `getSvnReadmeUrl(version)` helper — same convention
-- Added `getVersionedReleaseAssets(repo, targetDir, version)` — replaces `ghGetReleaseAssets`, filters releases by `v{version}.*` tag prefix
+- Added `getSvnDocbinUrl(version)` helper -- trunk for TRUNK_VERSION, branches/{version} otherwise
+- Added `getSvnReadmeUrl(version)` helper -- same convention
+- Added `getVersionedReleaseAssets(repo, targetDir, version)` -- replaces `ghGetReleaseAssets`, filters releases by `v{version}.*` tag prefix
 - Replaced `Checkout from svndocs` stage with per-version loop
 - Replaced `Get files from svn/docbin etc` stage with per-version loop
 - Replaced `Deploy site` stage with PRODUCTION_VERSIONS loop, source verification before touching production, deployed-count tracking
@@ -66,41 +66,42 @@ Tracking document for all tasks performed as part of the v21 branch strategy imp
   - Committed as `dec0eaa` "Apply v20-specific tweaks"
 - All pushes to `xpqz` remote only
 
-**Fork state after Test 2:**
+Fork state after Test 2:
+
 | Branch | Version | Submodule | Top commit |
 |--------|---------|-----------|------------|
 | `main` | 21.0 | `--remote` (latest) | `7cfc945` |
 | `v20.0` | "20.0" | `--init` (pinned) | `dec0eaa` |
-| `v21-branch-strategy` | 20.0 (unchanged) | — | `3889fda` |
-| `gh-pages` | — | — | Baseline v20 from Test 1 |
+| `v21-branch-strategy` | 20.0 (unchanged) | -- | `3889fda` |
+| `gh-pages` | -- | -- | Baseline v20 from Test 1 |
 
 ---
 
 ## Phase 3: Fork Testing (complete)
 
-### Test 3: Publish v20 from v20.0 branch — PASSED
+### Test 3: Publish v20 from v20.0 branch -- PASSED
 Run ID: 22628673123 (27m52s, success)
-- Version auto-detected as 20.0 — `Using mkdocs.yml version: 20.0`
+- Version auto-detected as 20.0 -- `Using mkdocs.yml version: 20.0`
 - Mike deployed 20.0/ to gh-pages
-- Jenkinsfile on gh-pages sourced from `origin/main` — confirmed `PRODUCTION_VERSIONS = '20.0'`, `TRUNK_VERSION = '21.0'`, all helper functions present
+- Jenkinsfile on gh-pages sourced from `origin/main` -- confirmed `PRODUCTION_VERSIONS = '20.0'`, `TRUNK_VERSION = '21.0'`, all helper functions present
 - Jenkins files committed to gh-pages as `e130526`
 - Site: https://xpqz.github.io/dyalog-docs/20.0/
 
-### Test 4: Publish v21 from main — PASSED
+### Test 4: Publish v21 from main -- PASSED
 Run ID: 22630553925 (27m33s, success)
-- Version auto-detected as 21.0 — `Using mkdocs.yml version: 21.0`
+- Version auto-detected as 21.0 -- `Using mkdocs.yml version: 21.0`
 - Mike deployed 21.0/ alongside 20.0/ on gh-pages
 - `versions.json` shows both: `21.0` and `20.0` (20.0 retains `latest` alias, correct)
 - Site: https://xpqz.github.io/dyalog-docs/21.0/
 
-### Test 5: Jenkins simulation — PASSED
+### Test 5: Jenkins simulation -- PASSED
 Run ID 22632056281 (56s, success): `production_versions: "20.0"`
 - Processed 20.0 only → Deployed 1 version
 
 Run ID 22632116644 (1m3s, success): `production_versions: "20.0 21.0"`
 - Processed 20.0 + 21.0 → Deployed 2 versions
 
-### Test 6: Offline build — PASSED
+### Test 6: Offline build -- PASSED
 Run ID: 22632414277 (28m54s, success)
 - Draft release created: `v21.0.1187`
 - Asset: `documentation-21.0-offline.zip` (153MB)
@@ -113,7 +114,7 @@ Skipped (non-critical). The concurrency group is configured; behaviour is standa
 
 ## Summary
 
-All implementation and fork testing is complete. The `v21-branch-strategy` branch contains all file changes. Tests 3–6 passed on the xpqz/dyalog-docs fork, confirming:
+Fork testing is complete. The `v21-branch-strategy` branch contains all file changes. Tests 3–6 passed on the xpqz/dyalog-docs fork, confirming:
 
 - Version auto-detection works from both branches
 - Both versions coexist on gh-pages (`versions.json` lists 20.0 and 21.0)
@@ -121,16 +122,16 @@ All implementation and fork testing is complete. The `v21-branch-strategy` branc
 - The PRODUCTION_VERSIONS deploy loop correctly filters versions
 - The offline build produces a versioned zip in a draft release
 
-### What's been built
+### Changes
 
 | File | Change |
 |------|--------|
 | `mkdocs-publish.yml` | Auto-detects version from `mkdocs.yml`, concurrency group, `set_as_latest` option, Jenkins files always sourced from `origin/main` |
-| `Jenkinsfile` | `PRODUCTION_VERSIONS` / `TRUNK_VERSION`, version-aware SVN paths, `getVersionedReleaseAssets` (replaces shared library call), per-version deploy loop with source verification |
+| `Jenkinsfile` | `PRODUCTION_VERSIONS` / `TRUNK_VERSION`, version-aware SVN paths, `getVersionedReleaseAssets` (replaces shared library call), per-version deploy loop with source verification, `gitdocs2svn` called per-version via env var override |
 | `.rsync-exclude` | `21.0` exclusion as defence-in-depth |
 | `mkdocs-offline.yml` | New offline zip workflow for v21+ (replaces CHM/PDF on main) |
 | `mkdocs-pdf.yml` | Offline bundle option added (from earlier chm-replacement work) |
-| `mkdocs.yml` | Offline plugin added |
+| `mkdocs.yml` | Offline plugin added for the CHM replacement |
 
 ---
 
@@ -138,21 +139,22 @@ All implementation and fork testing is complete. The `v21-branch-strategy` branc
 
 ### On Dyalog/documentation
 
-1. **Merge `v21-branch-strategy` into `main`** — PR review, then merge
-2. **Create `v20.0` branch from `main`** (before or after merge, same as fork test)
-3. **On `main`**: bump version to 21.0, quote `version_majmin`
-4. **On `v20.0`**: quote `version_majmin` as `"20.0"`, change submodule update to `--init`
-5. **Publish v20 from `v20.0`** — first real publish using new workflow
-6. **Publish v21 from `main`** — appears on GitHub Pages staging only
+1. Merge `v21-branch-strategy` into `main` -- PR review, then merge
+2. Create `v20.0` branch from `main` (before or after merge, same as fork test)
+3. On `main`: bump version to 21.0, quote `version_majmin`
+4. On `v20.0`: quote `version_majmin` as `"20.0"`, change submodule update to `--init`
+5. Publish v20 from `v20.0` -- first real publish using new workflow
+6. Publish v21 from `main` -- appears on GitHub Pages staging only
 
 ### Outside this repo
 
-- **`gitdocs2svn`** (in Dyalog/JenkinsBuild): may need a version parameter or loop to handle per-version SVN paths. Not a blocker for initial deployment — the `Update svndocs` stage can be limited to v20 initially.
-- **SVN branches**: no new SVN branches needed for v21 (it uses trunk). When v21 is eventually released and v22 starts, `docbin/branches/21.0/` and `dyalog/branches/21.0/` must exist before updating `TRUNK_VERSION`.
+- `gitdocs2svn` (in Dyalog/JenkinsBuild): no changes needed. The Jenkinsfile now calls it once per version, overriding `$SVNDOCDIR` and `$GITDOCDIR` to point at the per-version subdirectories.
+- `get_svn_docbin` (in this repo): works as-is for v20. Will need updating for v21 if/when docbin/trunk layout differs from v20, but only matters once v21 is added to `PRODUCTION_VERSIONS`.
+- SVN branches: no new SVN branches needed for v21 (it uses trunk). When v21 is eventually released and v22 starts, `docbin/branches/21.0/` and `dyalog/branches/21.0/` must exist before updating `TRUNK_VERSION`.
 
 ### When v21 goes to production
 
 1. Change `PRODUCTION_VERSIONS = '20.0'` → `'20.0 21.0'` in Jenkinsfile
 2. Remove `21.0` from `.rsync-exclude`
 3. Publish from main with `set_as_latest` checked
-4. Handle root redirect (`index.html` on production) — either extend deploy stage or manual step
+4. Handle root redirect (`index.html` on production) -- either extend deploy stage or manual step

--- a/tools/jenkins/steps21.md
+++ b/tools/jenkins/steps21.md
@@ -76,31 +76,83 @@ Tracking document for all tasks performed as part of the v21 branch strategy imp
 
 ---
 
-## Phase 3: Fork Testing (pending)
+## Phase 3: Fork Testing (complete)
 
-### Test 3: Publish v20 from v20.0 branch
-_Not yet started._ Run `mkdocs-publish.yml` from `v20.0` on fork. Verify:
-- Version auto-detected as 20.0
-- Mike deploys 20.0/ to gh-pages
-- Jenkinsfile on gh-pages comes from origin/main (has PRODUCTION_VERSIONS)
-- Site works at xpqz.github.io/documentation/20.0/
+### Test 3: Publish v20 from v20.0 branch — PASSED
+Run ID: 22628673123 (27m52s, success)
+- Version auto-detected as 20.0 — `Using mkdocs.yml version: 20.0`
+- Mike deployed 20.0/ to gh-pages
+- Jenkinsfile on gh-pages sourced from `origin/main` — confirmed `PRODUCTION_VERSIONS = '20.0'`, `TRUNK_VERSION = '21.0'`, all helper functions present
+- Jenkins files committed to gh-pages as `e130526`
+- Site: https://xpqz.github.io/dyalog-docs/20.0/
 
-### Test 4: Publish v21 from main
-_Not yet started._ Run `mkdocs-publish.yml` from `main` on fork. Verify:
-- Version auto-detected as 21.0
-- Mike deploys 21.0/ alongside 20.0/ on gh-pages
-- versions.json shows both versions
-- Site works at xpqz.github.io/documentation/21.0/
+### Test 4: Publish v21 from main — PASSED
+Run ID: 22630553925 (27m33s, success)
+- Version auto-detected as 21.0 — `Using mkdocs.yml version: 21.0`
+- Mike deployed 21.0/ alongside 20.0/ on gh-pages
+- `versions.json` shows both: `21.0` and `20.0` (20.0 retains `latest` alias, correct)
+- Site: https://xpqz.github.io/dyalog-docs/21.0/
 
-### Test 5: Jenkins simulation
-_Not yet started._ Run `test-jenkins-simulation.yml` with:
-- `production_versions: "20.0"` — should deploy only 20.0
-- `production_versions: "20.0 21.0"` — should deploy both
+### Test 5: Jenkins simulation — PASSED
+Run ID 22632056281 (56s, success): `production_versions: "20.0"`
+- Processed 20.0 only → Deployed 1 version
 
-### Test 6: Offline build
-_Not yet started._ Run `mkdocs-offline.yml` from `main` on fork. Verify:
-- Draft release created with `documentation-21.0-offline.zip`
-- Zip contains working offline site
+Run ID 22632116644 (1m3s, success): `production_versions: "20.0 21.0"`
+- Processed 20.0 + 21.0 → Deployed 2 versions
+
+### Test 6: Offline build — PASSED
+Run ID: 22632414277 (28m54s, success)
+- Draft release created: `v21.0.1187`
+- Asset: `documentation-21.0-offline.zip` (153MB)
+- Download and verify offline viewing manually if desired
 
 ### Test 7: Concurrency
-_Not yet started._ Trigger two publishes simultaneously. Confirm queuing.
+Skipped (non-critical). The concurrency group is configured; behaviour is standard GitHub Actions.
+
+---
+
+## Summary
+
+All implementation and fork testing is complete. The `v21-branch-strategy` branch contains all file changes. Tests 3–6 passed on the xpqz/dyalog-docs fork, confirming:
+
+- Version auto-detection works from both branches
+- Both versions coexist on gh-pages (`versions.json` lists 20.0 and 21.0)
+- Jenkins files on gh-pages are always sourced from `origin/main`
+- The PRODUCTION_VERSIONS deploy loop correctly filters versions
+- The offline build produces a versioned zip in a draft release
+
+### What's been built
+
+| File | Change |
+|------|--------|
+| `mkdocs-publish.yml` | Auto-detects version from `mkdocs.yml`, concurrency group, `set_as_latest` option, Jenkins files always sourced from `origin/main` |
+| `Jenkinsfile` | `PRODUCTION_VERSIONS` / `TRUNK_VERSION`, version-aware SVN paths, `getVersionedReleaseAssets` (replaces shared library call), per-version deploy loop with source verification |
+| `.rsync-exclude` | `21.0` exclusion as defence-in-depth |
+| `mkdocs-offline.yml` | New offline zip workflow for v21+ (replaces CHM/PDF on main) |
+| `mkdocs-pdf.yml` | Offline bundle option added (from earlier chm-replacement work) |
+| `mkdocs.yml` | Offline plugin added |
+
+---
+
+## Phase 4: Go Live (pending)
+
+### On Dyalog/documentation
+
+1. **Merge `v21-branch-strategy` into `main`** — PR review, then merge
+2. **Create `v20.0` branch from `main`** (before or after merge, same as fork test)
+3. **On `main`**: bump version to 21.0, quote `version_majmin`
+4. **On `v20.0`**: quote `version_majmin` as `"20.0"`, change submodule update to `--init`
+5. **Publish v20 from `v20.0`** — first real publish using new workflow
+6. **Publish v21 from `main`** — appears on GitHub Pages staging only
+
+### Outside this repo
+
+- **`gitdocs2svn`** (in Dyalog/JenkinsBuild): may need a version parameter or loop to handle per-version SVN paths. Not a blocker for initial deployment — the `Update svndocs` stage can be limited to v20 initially.
+- **SVN branches**: no new SVN branches needed for v21 (it uses trunk). When v21 is eventually released and v22 starts, `docbin/branches/21.0/` and `dyalog/branches/21.0/` must exist before updating `TRUNK_VERSION`.
+
+### When v21 goes to production
+
+1. Change `PRODUCTION_VERSIONS = '20.0'` → `'20.0 21.0'` in Jenkinsfile
+2. Remove `21.0` from `.rsync-exclude`
+3. Publish from main with `set_as_latest` checked
+4. Handle root redirect (`index.html` on production) — either extend deploy stage or manual step

--- a/tools/jenkins/steps21.md
+++ b/tools/jenkins/steps21.md
@@ -1,0 +1,106 @@
+# v21 Branch Strategy — Steps Performed
+
+Tracking document for all tasks performed as part of the v21 branch strategy implementation. See `plan21.md` for the full plan.
+
+---
+
+## Phase 1: Implementation (on `v21-branch-strategy` branch)
+
+### 1.1 Rewrite `mkdocs-publish.yml` (Plan Step 3)
+- Replaced manual `version` input with auto-detection from `mkdocs.yml` via `yq`
+- Added `version_override` optional input for edge cases
+- Added `set_as_latest` boolean input (controls mike aliases)
+- Added concurrency group (`docs-publish`, cancel-in-progress: false)
+- Changed "Copy Jenkins files to gh-pages" to always source from `origin/main` (not the triggering branch)
+- Pinned `yq` to v4.44.1
+
+### 1.2 Update `Jenkinsfile` (Plan Step 4)
+- Replaced `DOCSVERSION = '20.0'` with `PRODUCTION_VERSIONS = '20.0'` and `TRUNK_VERSION = '21.0'`
+- Removed hardcoded `SVNDOCURL` and `SVNREADMEURL` env vars
+- Added `getSvnDocbinUrl(version)` helper — trunk for TRUNK_VERSION, branches/{version} otherwise
+- Added `getSvnReadmeUrl(version)` helper — same convention
+- Added `getVersionedReleaseAssets(repo, targetDir, version)` — replaces `ghGetReleaseAssets`, filters releases by `v{version}.*` tag prefix
+- Replaced `Checkout from svndocs` stage with per-version loop
+- Replaced `Get files from svn/docbin etc` stage with per-version loop
+- Replaced `Deploy site` stage with PRODUCTION_VERSIONS loop, source verification before touching production, deployed-count tracking
+- Replaced `Verify deployment` stage with per-version index.html check
+- Updated `Backup current site` to backup only PRODUCTION_VERSIONS directories
+- Added PRODUCTION_VERSIONS and TRUNK_VERSION to Debug Environment output
+
+### 1.3 Update `.rsync-exclude` (Plan Step 5)
+- Added `21.0` line as defence-in-depth against accidental v21 production deployment
+
+### 1.4 Create `mkdocs-offline.yml` workflow
+- New dedicated offline build workflow for v21+
+- Produces `documentation-{version}-offline.zip`
+- Removes `navigation.instant` via `yq` (incompatible with `file://` URLs)
+- Creates draft GitHub release with tag `v{version}.{commit_count}`
+- Cleans up old drafts (keeps 5)
+
+### 1.5 Commit and push to fork
+- Committed as `3889fda` "Implement v21 branch strategy file changes"
+- Pushed to `xpqz` remote only (git@github.com:xpqz/dyalog-docs.git)
+- Origin (Dyalog/documentation) NOT touched
+
+---
+
+## Phase 2: Fork Setup for Testing
+
+### 2.1 Setup (completed in prior session)
+- Added fork as remote: `git remote add xpqz git@github.com:xpqz/dyalog-docs.git`
+- Pushed `v21-branch-strategy` branch to fork
+- Enabled GitHub Pages on fork (Settings → Pages → source: gh-pages)
+
+### 2.2 Test 1: Baseline v20 publish (completed in prior session)
+- Ran `mkdocs-publish.yml` from `main` on fork with version `20.0`
+- Populated gh-pages with known-good v20 baseline
+
+### 2.3 Test 2: Create branches and apply changes
+- Created `v20.0` branch on fork from current `main` (pre-merge state)
+- Merged `v21-branch-strategy` into fork's `main`, then:
+  - Bumped version to 21.0 (`version_maj: 21`, `version_majmin: "21.0"`, `version_condensed: 210`)
+  - Committed as `7cfc945` "Bump version to 21.0 on main"
+- Merged `v21-branch-strategy` into fork's `v20.0`, then:
+  - Quoted `version_majmin: "20.0"` (prevent YAML float coercion)
+  - Changed submodule update from `--remote` to `--init` (pin v20 assets)
+  - Committed as `dec0eaa` "Apply v20-specific tweaks"
+- All pushes to `xpqz` remote only
+
+**Fork state after Test 2:**
+| Branch | Version | Submodule | Top commit |
+|--------|---------|-----------|------------|
+| `main` | 21.0 | `--remote` (latest) | `7cfc945` |
+| `v20.0` | "20.0" | `--init` (pinned) | `dec0eaa` |
+| `v21-branch-strategy` | 20.0 (unchanged) | — | `3889fda` |
+| `gh-pages` | — | — | Baseline v20 from Test 1 |
+
+---
+
+## Phase 3: Fork Testing (pending)
+
+### Test 3: Publish v20 from v20.0 branch
+_Not yet started._ Run `mkdocs-publish.yml` from `v20.0` on fork. Verify:
+- Version auto-detected as 20.0
+- Mike deploys 20.0/ to gh-pages
+- Jenkinsfile on gh-pages comes from origin/main (has PRODUCTION_VERSIONS)
+- Site works at xpqz.github.io/documentation/20.0/
+
+### Test 4: Publish v21 from main
+_Not yet started._ Run `mkdocs-publish.yml` from `main` on fork. Verify:
+- Version auto-detected as 21.0
+- Mike deploys 21.0/ alongside 20.0/ on gh-pages
+- versions.json shows both versions
+- Site works at xpqz.github.io/documentation/21.0/
+
+### Test 5: Jenkins simulation
+_Not yet started._ Run `test-jenkins-simulation.yml` with:
+- `production_versions: "20.0"` — should deploy only 20.0
+- `production_versions: "20.0 21.0"` — should deploy both
+
+### Test 6: Offline build
+_Not yet started._ Run `mkdocs-offline.yml` from `main` on fork. Verify:
+- Draft release created with `documentation-21.0-offline.zip`
+- Zip contains working offline site
+
+### Test 7: Concurrency
+_Not yet started._ Trigger two publishes simultaneously. Confirm queuing.


### PR DESCRIPTION
## Summary

- Implement multi-version publish workflow (auto-detect version from mkdocs.yml)
- Update Jenkinsfile: PRODUCTION_VERSIONS loop, version-aware SVN, getVersionedReleaseAssets
- Add offline build workflow for v21+
- Add .rsync-exclude defence-in-depth for 21.0
- Include plan, steps tracking, IT briefing, and email summary docs

## Test results (on this fork)

- Test 3: Publish v20 from v20.0 branch — PASSED
- Test 4: Publish v21 from main — PASSED
- Test 5: Jenkins simulation (selective deploy) — PASSED
- Test 6: Offline build — PASSED

See `tools/jenkins/steps21.md` for details.